### PR TITLE
Add Typer-based CLI with repository parser

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.0
+    rev: v1.19.1
     hooks:
       - id: mypy
-        additional_dependencies: []
+        additional_dependencies: [typer]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.4
+    rev: v0.14.10
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.2.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "typer>=0.21.0",
+]
 
 [dependency-groups]
 dev = [

--- a/src/review_classification/cli/__init__.py
+++ b/src/review_classification/cli/__init__.py
@@ -1,0 +1,5 @@
+"""CLI module for review-classification."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/src/review_classification/cli/app.py
+++ b/src/review_classification/cli/app.py
@@ -9,7 +9,7 @@ from .parser import GitHubRepo
 app = typer.Typer(help="Identify PR review outliers in GitHub repositories")
 
 
-@app.command()  # type: ignore[misc]
+@app.command()
 def classify(
     repository: Annotated[
         str, typer.Argument(help="GitHub repository (owner/repo or URL)")

--- a/src/review_classification/cli/app.py
+++ b/src/review_classification/cli/app.py
@@ -1,0 +1,51 @@
+"""Typer CLI application for review-classification."""
+
+from typing import Annotated
+
+import typer
+
+from .parser import GitHubRepo
+
+app = typer.Typer(help="Identify PR review outliers in GitHub repositories")
+
+
+@app.command()  # type: ignore[misc]
+def classify(
+    repository: Annotated[
+        str, typer.Argument(help="GitHub repository (owner/repo or URL)")
+    ],
+    start_date: Annotated[
+        str | None,
+        typer.Option("--start", "-s", help="Start date for PR range (YYYY-MM-DD)"),
+    ] = None,
+    end_date: Annotated[
+        str | None,
+        typer.Option("--end", "-e", help="End date for PR range (YYYY-MM-DD)"),
+    ] = None,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", "-v", help="Enable verbose output")
+    ] = False,
+) -> None:
+    """Classify PR review outliers in a GitHub repository.
+
+    Analyzes pull requests merged within the specified date range and identifies
+    outliers based on review time, number of reviews, and qualitative metrics.
+    """
+    try:
+        repo = GitHubRepo.from_string(repository)
+
+        if verbose:
+            typer.echo(f"Repository: {repo.owner}/{repo.name}")
+            if start_date:
+                typer.echo(f"Start date: {start_date}")
+            if end_date:
+                typer.echo(f"End date: {end_date}")
+
+        typer.echo(f"Analyzing {repo.owner}/{repo.name}...")
+
+        # TODO: Implement PR analysis logic
+        typer.echo("Analysis not yet implemented - coming soon!")
+
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=1) from e

--- a/src/review_classification/cli/parser.py
+++ b/src/review_classification/cli/parser.py
@@ -1,0 +1,51 @@
+"""GitHub repository parser for various input formats."""
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class GitHubRepo:
+    """Represents a GitHub repository with owner and name."""
+
+    owner: str
+    name: str
+
+    @classmethod
+    def from_string(cls, repo_input: str) -> "GitHubRepo":
+        """Parse various GitHub repo formats.
+
+        Supports:
+        - owner/repo
+        - https://github.com/owner/repo
+        - https://github.com/owner/repo.git
+        - git@github.com:owner/repo.git
+
+        Args:
+            repo_input: Repository identifier in various formats
+
+        Returns:
+            GitHubRepo instance
+
+        Raises:
+            ValueError: If the repository format is invalid
+        """
+        # Remove .git suffix if present
+        repo_input = repo_input.removesuffix(".git")
+
+        # GitHub URL patterns
+        https_pattern = r"https?://github\.com/([^/]+)/([^/]+)"
+        ssh_pattern = r"git@github\.com:([^/]+)/([^/]+)"
+
+        if (match := re.match(https_pattern, repo_input)) or (
+            match := re.match(ssh_pattern, repo_input)
+        ):
+            return cls(owner=match.group(1), name=match.group(2))
+        elif "/" in repo_input:
+            owner, name = repo_input.split("/", 1)
+            return cls(owner=owner.strip(), name=name.strip())
+        else:
+            raise ValueError(
+                f"Invalid repository format: {repo_input}\n"
+                "Expected: owner/repo or GitHub URL"
+            )

--- a/src/review_classification/main.py
+++ b/src/review_classification/main.py
@@ -1,5 +1,11 @@
+"""Main entry point for review-classification CLI."""
+
+from .cli import app
+
+
 def main() -> None:
-    print("Hello from review-classification!")
+    """Run the CLI application."""
+    app()
 
 
 if __name__ == "__main__":

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for CLI module."""

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -1,6 +1,7 @@
 """Tests for GitHub repository parser."""
 
 import pytest
+
 from review_classification.cli.parser import GitHubRepo
 
 

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -1,0 +1,67 @@
+"""Tests for GitHub repository parser."""
+
+import pytest
+from review_classification.cli.parser import GitHubRepo
+
+
+def test_parse_owner_slash_repo() -> None:
+    """Test parsing owner/repo format."""
+    repo = GitHubRepo.from_string("owner/repo")
+    assert repo.owner == "owner"
+    assert repo.name == "repo"
+
+
+def test_parse_https_url() -> None:
+    """Test parsing HTTPS GitHub URL."""
+    repo = GitHubRepo.from_string("https://github.com/owner/repo")
+    assert repo.owner == "owner"
+    assert repo.name == "repo"
+
+
+def test_parse_https_url_with_git_suffix() -> None:
+    """Test parsing HTTPS URL with .git suffix."""
+    repo = GitHubRepo.from_string("https://github.com/owner/repo.git")
+    assert repo.owner == "owner"
+    assert repo.name == "repo"
+
+
+def test_parse_http_url() -> None:
+    """Test parsing HTTP GitHub URL."""
+    repo = GitHubRepo.from_string("http://github.com/owner/repo")
+    assert repo.owner == "owner"
+    assert repo.name == "repo"
+
+
+def test_parse_ssh_url() -> None:
+    """Test parsing SSH GitHub URL."""
+    repo = GitHubRepo.from_string("git@github.com:owner/repo")
+    assert repo.owner == "owner"
+    assert repo.name == "repo"
+
+
+def test_parse_ssh_url_with_git_suffix() -> None:
+    """Test parsing SSH URL with .git suffix."""
+    repo = GitHubRepo.from_string("git@github.com:owner/repo.git")
+    assert repo.owner == "owner"
+    assert repo.name == "repo"
+
+
+def test_parse_with_whitespace() -> None:
+    """Test parsing with surrounding whitespace."""
+    repo = GitHubRepo.from_string(" owner / repo ")
+    assert repo.owner == "owner"
+    assert repo.name == "repo"
+
+
+def test_parse_invalid_format() -> None:
+    """Test that invalid format raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid repository format"):
+        GitHubRepo.from_string("invalid")
+
+
+def test_parse_invalid_format_error_message() -> None:
+    """Test that error message is helpful."""
+    with pytest.raises(ValueError) as exc_info:
+        GitHubRepo.from_string("justareponame")
+
+    assert "Expected: owner/repo or GitHub URL" in str(exc_info.value)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,8 @@
+"""Tests for main module."""
+
 from review_classification.main import main
 
 
 def test_main_import() -> None:
+    """Test that main function is callable."""
     assert callable(main)

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -106,6 +118,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/33/13a4cb798a171b173f3c94db23adaf13a417130e1493933dc0df0d7fb439/librt-0.7.5-cp314-cp314t-win32.whl", hash = "sha256:118716de5ad6726332db1801bc90fa6d94194cd2e07c1a7822cebf12c496714d", size = 40282, upload-time = "2025-12-25T03:53:01.091Z" },
     { url = "https://files.pythonhosted.org/packages/5f/f1/62b136301796399d65dad73b580f4509bcbd347dff885a450bff08e80cb6/librt-0.7.5-cp314-cp314t-win_amd64.whl", hash = "sha256:3dd58f7ce20360c6ce0c04f7bd9081c7f9c19fc6129a3c705d0c5a35439f201d", size = 46764, upload-time = "2025-12-25T03:53:02.381Z" },
     { url = "https://files.pythonhosted.org/packages/49/cb/940431d9410fda74f941f5cd7f0e5a22c63be7b0c10fa98b2b7022b48cb1/librt-0.7.5-cp314-cp314t-win_arm64.whl", hash = "sha256:08153ea537609d11f774d2bfe84af39d50d5c9ca3a4d061d946e0c9d8bce04a1", size = 39728, upload-time = "2025-12-25T03:53:03.306Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -286,6 +319,9 @@ wheels = [
 name = "review-classification"
 version = "0.2.3"
 source = { editable = "." }
+dependencies = [
+    { name = "typer" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -296,6 +332,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "typer", specifier = ">=0.21.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -303,6 +340,19 @@ dev = [
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.14.10" },
+]
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
 ]
 
 [[package]]
@@ -329,6 +379,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/1c/d7b67ab43f30013b47c12b42d1acd354c195351a3f7a1d67f59e54227ede/ruff-0.14.10-py3-none-win32.whl", hash = "sha256:104c49fc7ab73f3f3a758039adea978869a918f31b73280db175b43a2d9b51d6", size = 13196187, upload-time = "2025-12-18T19:29:19.006Z" },
     { url = "https://files.pythonhosted.org/packages/fb/9c/896c862e13886fae2af961bef3e6312db9ebc6adc2b156fe95e615dee8c1/ruff-0.14.10-py3-none-win_amd64.whl", hash = "sha256:466297bd73638c6bdf06485683e812db1c00c7ac96d4ddd0294a338c62fdc154", size = 14661283, upload-time = "2025-12-18T19:29:30.16Z" },
     { url = "https://files.pythonhosted.org/packages/74/31/b0e29d572670dca3674eeee78e418f20bdf97fa8aa9ea71380885e175ca0/ruff-0.14.10-py3-none-win_arm64.whl", hash = "sha256:e51d046cf6dda98a4633b8a8a771451107413b0f07183b2bef03f075599e44e6", size = 13729839, upload-time = "2025-12-18T19:28:48.636Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/30/ff9ede605e3bd086b4dd842499814e128500621f7951ca1e5ce84bbf61b1/typer-0.21.0.tar.gz", hash = "sha256:c87c0d2b6eee3b49c5c64649ec92425492c14488096dfbc8a0c2799b2f6f9c53", size = 106781, upload-time = "2025-12-25T09:54:53.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/e4/5ebc1899d31d2b1601b32d21cfb4bba022ae6fce323d365f0448031b1660/typer-0.21.0-py3-none-any.whl", hash = "sha256:c79c01ca6b30af9fd48284058a7056ba0d3bf5cf10d0ff3d0c5b11b68c258ac6", size = 47109, upload-time = "2025-12-25T09:54:51.918Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements a Typer-based CLI framework with support for parsing GitHub repository names in multiple formats.

## Changes

### CLI Module (`src/review_classification/cli/`)
- **app.py**: Typer CLI application with `classify` command
  - Accepts repository argument (required)
  - Optional `--start`/`-s` for start date
  - Optional `--end`/`-e` for end date
  - Optional `--verbose`/`-v` flag
- **parser.py**: `GitHubRepo` parser supporting multiple input formats:
  - `owner/repo`
  - `https://github.com/owner/repo`
  - `https://github.com/owner/repo.git`
  - `git@github.com:owner/repo`
  - `git@github.com:owner/repo.git`

### Testing
- Added 9 comprehensive parser tests in `tests/cli/test_parser.py`
- All tests passing ✅
- Mypy strict type checking passing ✅
- Ruff linting passing ✅

### Dependencies
- Added `typer` (brings in `click`, `rich`, `shellingham`)

## Usage Examples

```bash
# Basic usage
review-classify owner/repo

# With date range
review-classify expressjs/express --start 2024-01-01 --end 2024-12-31

# Using GitHub URL with verbose output
review-classify https://github.com/owner/repo -v

# Show help
review-classify --help
```

## Next Steps

This PR lays the foundation for the PR analysis functionality. Future work will include:
- GitHub API integration
- PR data fetching with rate limiting
- SQLite caching
- Outlier detection algorithms

🤖 Generated with [Claude Code](https://claude.com/claude-code)