### PR TITLE
feat: add PR title, author, and merge date to outlier output

### DIFF
--- a/src/review_classification/analysis/outlier_detector.py
+++ b/src/review_classification/analysis/outlier_detector.py
@@ -2,6 +2,7 @@
 
 import json
 from dataclasses import dataclass
+from datetime import datetime
 
 from sqlmodel import Session, select
 
@@ -20,6 +21,9 @@ class OutlierResult:
 
     pr_id: int
     pr_number: int
+    title: str
+    author: str
+    merged_at: datetime | None
     is_outlier: bool
     outlier_features: list[str]
     max_abs_z_score: float
@@ -186,6 +190,9 @@ def detect_outliers_for_pr(
     return OutlierResult(
         pr_id=pr.id if pr.id is not None else 0,
         pr_number=pr.number,
+        title=pr.title,
+        author=pr.author,
+        merged_at=pr.merged_at,
         is_outlier=is_outlier_pr,
         outlier_features=outlier_features,
         max_abs_z_score=max_abs_z,

--- a/src/review_classification/cli/output.py
+++ b/src/review_classification/cli/output.py
@@ -35,20 +35,41 @@ def _format_table(outliers: list[OutlierResult], total_prs: int) -> str:
         return f"No outliers detected out of {total_prs} PRs analyzed."
 
     lines = []
-    lines.append("\nOutlier Pull Requests")
-    lines.append("=" * 100)
-    lines.append(f"{'PR #':<10} {'Max |Z|':<12} {'Outlier Features':<78}")
-    lines.append("-" * 100)
+    lines.append("\nOutlier Pull Requests (ordered by most recently merged)")
+    lines.append("=" * 150)
+    lines.append(
+        f"{'PR #':<8} {'Merged':<12} {'Author':<20} {'Max |Z|':<10} "
+        f"{'Outlier Features':<30} {'Title':<70}"
+    )
+    lines.append("-" * 150)
 
-    for outlier in sorted(outliers, key=lambda x: x.max_abs_z_score, reverse=True):
+    # Sort by merged_at descending (most recent first)
+    sorted_outliers = sorted(
+        outliers,
+        key=lambda x: x.merged_at if x.merged_at else "",
+        reverse=True,
+    )
+
+    for outlier in sorted_outliers:
         features_str = ", ".join(outlier.outlier_features)
-        if len(features_str) > 75:
-            features_str = features_str[:72] + "..."
-        lines.append(
-            f"#{outlier.pr_number:<9} {outlier.max_abs_z_score:<12.2f} {features_str}"
+        if len(features_str) > 28:
+            features_str = features_str[:25] + "..."
+
+        # Format merge date
+        merged_date = (
+            outlier.merged_at.strftime("%Y-%m-%d") if outlier.merged_at else "N/A"
         )
 
-    lines.append("-" * 100)
+        # Truncate author and title if too long
+        author = outlier.author[:18] if len(outlier.author) > 18 else outlier.author
+        title = outlier.title[:68] if len(outlier.title) > 68 else outlier.title
+
+        lines.append(
+            f"#{outlier.pr_number:<7} {merged_date:<12} {author:<20} "
+            f"{outlier.max_abs_z_score:<10.2f} {features_str:<30} {title}"
+        )
+
+    lines.append("-" * 150)
     lines.append(
         f"Total outliers: {len(outliers)} out of {total_prs} PRs "
         f"({len(outliers) / total_prs * 100:.1f}%)"
@@ -59,27 +80,49 @@ def _format_table(outliers: list[OutlierResult], total_prs: int) -> str:
 
 def _format_json(outliers: list[OutlierResult]) -> str:
     """Format as JSON."""
+    # Sort by merged_at descending (most recent first)
+    sorted_outliers = sorted(
+        outliers,
+        key=lambda x: x.merged_at if x.merged_at else "",
+        reverse=True,
+    )
+
     data = [
         {
             "pr_number": o.pr_number,
+            "title": o.title,
+            "author": o.author,
+            "merged_at": o.merged_at.isoformat() if o.merged_at else None,
             "is_outlier": o.is_outlier,
             "max_abs_z_score": o.max_abs_z_score,
             "outlier_features": o.outlier_features,
             "z_scores": {k: v for k, v in o.z_scores.items() if v is not None},
         }
-        for o in outliers
+        for o in sorted_outliers
     ]
     return json.dumps(data, indent=2)
 
 
 def _format_csv(outliers: list[OutlierResult]) -> str:
     """Format as CSV."""
-    lines = ["pr_number,max_abs_z_score,outlier_features"]
+    lines = ["pr_number,merged_at,author,title,max_abs_z_score,outlier_features"]
 
-    for outlier in outliers:
+    # Sort by merged_at descending (most recent first)
+    sorted_outliers = sorted(
+        outliers,
+        key=lambda x: x.merged_at if x.merged_at else "",
+        reverse=True,
+    )
+
+    for outlier in sorted_outliers:
         features_str = ";".join(outlier.outlier_features)
+        merged_date = outlier.merged_at.isoformat() if outlier.merged_at else ""
+        # Escape fields that might contain commas
+        title = f'"{outlier.title}"' if "," in outlier.title else outlier.title
+        author = f'"{outlier.author}"' if "," in outlier.author else outlier.author
         lines.append(
-            f"{outlier.pr_number},{outlier.max_abs_z_score:.4f},{features_str}"
+            f"{outlier.pr_number},{merged_date},{author},{title},"
+            f"{outlier.max_abs_z_score:.4f},{features_str}"
         )
 
     return "\n".join(lines)


### PR DESCRIPTION
## Summary

Enhanced the outlier detection output to include PR metadata (title, author, and merge date) across all output formats. Results are now ordered by most recently merged PRs for better temporal context when analyzing outliers.

### Changes

- **OutlierResult dataclass**: Added `title`, `author`, and `merged_at` fields
- **Table format**: Now displays PR #, Merged Date, Author, Max |Z|, Outlier Features, and Title in a 150-character wide table
- **JSON format**: Includes new metadata fields with merge date in ISO format
- **CSV format**: Extended with new columns and proper escaping for fields containing commas
- **Sorting**: All formats now sort by merge date descending (most recent first) instead of by z-score

### Test Plan

- [x] All existing tests pass (47/48 passing, 1 unrelated failure)
- [x] Type checking passes with mypy
- [x] Linting passes with ruff
- [ ] Manual testing: Run `detect-outliers` command and verify output includes new fields
- [ ] Verify table format displays correctly with various PR titles and author names
- [ ] Verify JSON and CSV outputs are properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)