### PR TITLE
feat: rename and extend PyPI publish workflow to support test and production targets

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,16 +1,25 @@
-name: Publish to TestPyPI
+name: Publish to PyPI
 
 on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      target:
+        description: 'Publish target'
+        required: true
+        default: 'test'
+        type: choice
+        options:
+          - test
+          - production
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/review-classification
+      name: ${{ (inputs.target == 'production' || github.event_name == 'release') && 'pypi' || 'testpypi' }}
+      url: ${{ (inputs.target == 'production' || github.event_name == 'release') && 'https://pypi.org/p/review-classification' || 'https://test.pypi.org/p/review-classification' }}
     permissions:
       id-token: write
       contents: write  # Required to push version bump commit
@@ -41,7 +50,12 @@ jobs:
         run: uv build
 
       - name: Publish to TestPyPI
+        if: inputs.target == 'test' && github.event_name == 'workflow_dispatch'
         run: uv publish --publish-url https://test.pypi.org/legacy/ --token ${{ secrets.UV_PUBLISH_TOKEN_TEST }}
+
+      - name: Publish to PyPI
+        if: inputs.target == 'production' || github.event_name == 'release'
+        run: uv publish --token ${{ secrets.UV_PUBLISH_TOKEN }}
 
       - name: Commit Patch Bump
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ __marimo__/
 claude.local.md
 .idea
 review_classification.db
+.mcp.json


### PR DESCRIPTION
## Summary

- Renames `pypi_pub_to_test.yml` to `pypi_publish.yml` to reflect its expanded scope
- Adds a `workflow_dispatch` input to choose between `test` and `production` publish targets
- On manual dispatch with `production` target or on release events, publishes to the real PyPI using `UV_PUBLISH_TOKEN`
- On manual dispatch with `test` target, continues publishing to TestPyPI as before
- Adds `.mcp.json` to `.gitignore`

## Test plan

- [ ] Trigger workflow manually with `target: test` — verify it publishes to TestPyPI
- [ ] Trigger workflow manually with `target: production` — verify it publishes to PyPI
- [ ] Create a release — verify it publishes to PyPI automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)