### PR TITLE
feat: baseline window for outlier detection and rename classify to fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,135 @@
 # Review Classification
 
-A CLI tool to identify pull request outliers in GitHub repositories based on review time, size, and qualitative metrics. This tool helps engineering teams understand review patterns and identify unusual PRs that might need attention.
+A CLI tool to identify pull request outliers in GitHub repositories using Z-score analysis. Helps engineering teams spot unusual PRs — by size, review duration, comment activity, or code churn — against a stable historical baseline.
 
 ## Features
 
-*   **Fetch & Store**: efficiently retrieve PR data from GitHub (handling rate limits) and store locally in a SQLite database.
-*   **Outlier Detection**: Detect statistical outliers using Z-score analysis on multiple metrics (review duration, size, comments, etc.).
-*   **Analysis**: Calculate rich features like code churn, comment density, and review speed.
-*   **Flexible Output**: view results in the terminal as tables, or export to JSON/CSV for further analysis.
+- **Fetch & Store**: retrieve PR data from GitHub (with rate-limit handling) and store it in a local SQLite database.
+- **Outlier Detection**: Z-score analysis across multiple metrics — additions, deletions, changed files, comments, review duration, code churn, and comment density.
+- **Baseline window**: define a historical measurement period so recent PRs are evaluated against an independent baseline rather than skewing their own statistics.
+- **Flexible output**: view results as a terminal table or export to JSON/CSV.
 
 ## Installation
 
-**Prerequisites**:
-*   Python 3.12 or higher
-*   [uv](https://github.com/astral-sh/uv) (recommended for dependency management)
+**Prerequisites**: Python 3.12+, [uv](https://github.com/astral-sh/uv)
 
-### Setup
-
-1.  Clone the repository:
-    ```bash
-    git clone https://github.com/ghinks/review-classification.git
-    cd review-classification
-    ```
-
-2.  Install dependencies:
-    ```bash
-    uv sync
-    ```
+```bash
+git clone https://github.com/ghinks/review-classification.git
+cd review-classification
+uv sync
+```
 
 ## Usage
 
-### 1. Configure GitHub Token
+The tool works in two steps: **fetch** data, then **detect-outliers**.
 
-To avoid rate limits, you must set a GitHub personal access token:
+### 1. Configure GitHub Token
 
 ```bash
 export GITHUB_TOKEN=your_token_here
 ```
 
-### 2. Classify (Fetch Data)
+Without a token the GitHub API rate limit is very low.
 
-The `classify` command fetches PR data from a repository and stores it locally.
+### 2. `fetch` — retrieve and store PR data
 
 ```bash
-# Fetch all PRs
-uv run review-classify classify owner/repo
-
-(default start date is 30 days ago)
+# Fetch PRs merged in the last 30 days (default)
+uv run review-classify fetch owner/repo
 
 # Fetch PRs within a specific date range
-uv run review-classify classify owner/repo --start 2023-01-01 --end 2023-12-31
+uv run review-classify fetch owner/repo --start 2024-01-01 --end 2024-06-30
 
-# Reset the local database before fetching
-uv run review-classify classify owner/repo --reset-db
+# Clear existing data before fetching
+uv run review-classify fetch owner/repo --reset-db --start 2024-01-01
 ```
 
-### 3. Detect Outliers
+| Option | Description |
+| --- | --- |
+| `--start` / `-s` | Start date for PR range (YYYY-MM-DD). Defaults to 30 days ago. |
+| `--end` / `-e` | End date for PR range (YYYY-MM-DD). |
+| `--reset-db` | Delete all stored data before fetching. |
+| `--verbose` / `-v` | Print progress details. |
 
-The `detect-outliers` command analyzes the stored data to find unusual PRs.
+### 3. `detect-outliers` — find unusual PRs
 
 ```bash
-# Basic outlier detection (default threshold: 2.0)
+# Detect outliers across all stored PRs
 uv run review-classify detect-outliers owner/repo
 
-# rigorous detection (higher threshold)
+# Stricter threshold (fewer, more extreme outliers)
 uv run review-classify detect-outliers owner/repo --threshold 3.0
 
-# Export results to JSON
+# Export to JSON
 uv run review-classify detect-outliers owner/repo --format json > outliers.json
+```
+
+| Option | Description |
+| --- | --- |
+| `--threshold` / `-t` | Z-score threshold for flagging an outlier. Default: `2.0`. |
+| `--min-samples` | Minimum number of PRs required for analysis. Default: `30`. |
+| `--format` / `-f` | Output format: `table` (default), `json`, or `csv`. |
+| `--classify-start` | Start of the baseline measurement window (YYYY-MM-DD). |
+| `--classify-end` | End of the baseline measurement window (YYYY-MM-DD). |
+| `--verbose` / `-v` | Print progress details. |
+
+#### Baseline window (`--classify-start` / `--classify-end`)
+
+By default all stored PRs feed both the baseline statistics and the outlier evaluation. This is problematic: an unusually large PR inflates the mean and standard deviation it is measured against, masking itself as normal.
+
+Use `--classify-start` and `--classify-end` to define a historical baseline window. Statistics are computed from PRs merged **within** that window; only PRs merged **after** `--classify-end` are evaluated and reported.
+
+```
+[--classify-start ────────── --classify-end]   >classify-end
+         ↑                         ↑                 ↑
+   baseline start            baseline end     PRs evaluated here
+```
+
+```bash
+# Use Jan–Jun 2024 as the baseline; evaluate PRs merged after 2024-06-30
+uv run review-classify detect-outliers owner/repo \
+  --classify-start 2024-01-01 \
+  --classify-end   2024-06-30
+
+# Same, with stricter threshold and JSON output
+uv run review-classify detect-outliers owner/repo \
+  --classify-start 2024-01-01 \
+  --classify-end   2024-06-30 \
+  --threshold 2.5 \
+  --format json > outliers.json
+```
+
+### End-to-end example
+
+```bash
+# 1. Fetch a full year of history as the baseline
+uv run review-classify fetch owner/repo \
+  --start 2024-01-01 --end 2024-12-31
+
+# 2. Evaluate PRs from January 2025 against that baseline
+uv run review-classify detect-outliers owner/repo \
+  --classify-start 2024-01-01 \
+  --classify-end   2024-12-31 \
+  --format table
 ```
 
 ## Development
 
 ### Setup
 
-Install dev dependencies:
 ```bash
 uv sync --group dev
 ```
 
 ### Running Tests
 
-Run the test suite with pytest:
 ```bash
 uv run pytest
 ```
 
 ### Linting & Formatting
 
-This project uses `ruff` for linting and formatting and `mypy` for static type checking.
-
 ```bash
-# Run pre-commit hooks on all files
+# Run ruff (lint + format) and mypy via pre-commit
 uv run pre-commit run --all-files
 ```

--- a/src/review_classification/analysis/outlier_detector.py
+++ b/src/review_classification/analysis/outlier_detector.py
@@ -34,6 +34,8 @@ def calculate_repository_statistics(
     session: Session,
     repository_name: str,
     min_sample_size: int = 30,
+    stats_start: datetime | None = None,
+    stats_end: datetime | None = None,
 ) -> tuple[dict[str, dict[str, float]], int]:
     """Calculate statistics for all metrics in a repository.
 
@@ -41,6 +43,8 @@ def calculate_repository_statistics(
         session: Database session
         repository_name: Repository to analyze
         min_sample_size: Minimum PRs needed for analysis
+        stats_start: Only include PRs merged on or after this date in statistics
+        stats_end: Only include PRs merged on or before this date in statistics
 
     Returns:
         Tuple of (metric_stats, sample_count) where metric_stats is a dict
@@ -49,11 +53,17 @@ def calculate_repository_statistics(
     Raises:
         InsufficientDataError: If repository has insufficient merged PRs
     """
-    # Fetch all merged PRs for this repository
+    # Fetch merged PRs for this repository, optionally restricted to a date range
     statement = select(PullRequest).where(
         PullRequest.repository_name == repository_name,
         PullRequest.merged_at.is_not(None),  # type: ignore[union-attr]
     )
+
+    if stats_start:
+        statement = statement.where(PullRequest.merged_at >= stats_start)
+    if stats_end:
+        statement = statement.where(PullRequest.merged_at <= stats_end)
+
     prs = list(session.exec(statement).all())
 
     if len(prs) < min_sample_size:
@@ -205,6 +215,8 @@ def detect_outliers_for_repository(
     repository_name: str,
     min_sample_size: int = 30,
     threshold: float = 2.0,
+    classify_start: datetime | None = None,
+    classify_end: datetime | None = None,
 ) -> list[OutlierResult]:
     """Detect outliers for all PRs in a repository.
 
@@ -213,6 +225,11 @@ def detect_outliers_for_repository(
         repository_name: Repository to analyze
         min_sample_size: Minimum PRs needed for analysis
         threshold: Z-score threshold for outlier detection
+        classify_start: Start of the baseline measurement window used to compute
+            statistics. PRs merged before this date are excluded from the baseline.
+        classify_end: End of the baseline measurement window. PRs merged after this
+            date are the ones evaluated for outliers. PRs within
+            [classify_start, classify_end] form the baseline.
 
     Returns:
         List of OutlierResult for each PR
@@ -220,16 +237,26 @@ def detect_outliers_for_repository(
     Raises:
         InsufficientDataError: If repository has insufficient data
     """
-    # Calculate repository statistics
+    # Calculate baseline statistics from PRs within the classification window
     stats, _ = calculate_repository_statistics(
-        session, repository_name, min_sample_size
+        session,
+        repository_name,
+        min_sample_size,
+        stats_start=classify_start,
+        stats_end=classify_end,
     )
 
-    # Fetch all PRs and features
+    # Fetch PRs to evaluate: those after the classification window
     statement = select(PullRequest).where(
         PullRequest.repository_name == repository_name,
         PullRequest.merged_at.is_not(None),  # type: ignore[union-attr]
     )
+
+    if classify_end:
+        statement = statement.where(PullRequest.merged_at > classify_end)
+    elif classify_start:
+        statement = statement.where(PullRequest.merged_at >= classify_start)
+
     prs = list(session.exec(statement).all())
 
     pr_ids = [pr.id for pr in prs if pr.id is not None]

--- a/src/review_classification/analysis/outlier_detector.py
+++ b/src/review_classification/analysis/outlier_detector.py
@@ -60,9 +60,9 @@ def calculate_repository_statistics(
     )
 
     if stats_start:
-        statement = statement.where(PullRequest.merged_at >= stats_start)
+        statement = statement.where(PullRequest.merged_at >= stats_start)  # type: ignore[operator]
     if stats_end:
-        statement = statement.where(PullRequest.merged_at <= stats_end)
+        statement = statement.where(PullRequest.merged_at <= stats_end)  # type: ignore[operator]
 
     prs = list(session.exec(statement).all())
 
@@ -253,9 +253,9 @@ def detect_outliers_for_repository(
     )
 
     if classify_end:
-        statement = statement.where(PullRequest.merged_at > classify_end)
+        statement = statement.where(PullRequest.merged_at > classify_end)  # type: ignore[operator]
     elif classify_start:
-        statement = statement.where(PullRequest.merged_at >= classify_start)
+        statement = statement.where(PullRequest.merged_at >= classify_start)  # type: ignore[operator]
 
     prs = list(session.exec(statement).all())
 

--- a/src/review_classification/cli/app.py
+++ b/src/review_classification/cli/app.py
@@ -11,7 +11,7 @@ app = typer.Typer(help="Identify PR review outliers in GitHub repositories")
 
 
 @app.command()
-def classify(
+def fetch(
     repository: Annotated[
         str, typer.Argument(help="GitHub repository (owner/repo or URL)")
     ],
@@ -31,10 +31,10 @@ def classify(
         bool, typer.Option("--verbose", "-v", help="Enable verbose output")
     ] = False,
 ) -> None:
-    """Classify PR review outliers in a GitHub repository.
+    """Fetch PR data from a GitHub repository and store it locally.
 
-    Analyzes pull requests merged within the specified date range and identifies
-    outliers based on review time, number of reviews, and qualitative metrics.
+    Retrieves pull requests merged within the specified date range and saves
+    them to a local SQLite database for subsequent outlier analysis.
     """
     try:
         repo = GitHubRepo.from_string(repository)
@@ -109,6 +109,26 @@ def detect_outliers(
     verbose: Annotated[
         bool, typer.Option("--verbose", "-v", help="Enable verbose output")
     ] = False,
+    classify_start: Annotated[
+        str | None,
+        typer.Option(
+            "--classify-start",
+            help=(
+                "Start of the baseline measurement window (YYYY-MM-DD). "
+                "PRs after --classify-end are evaluated for outliers."
+            ),
+        ),
+    ] = None,
+    classify_end: Annotated[
+        str | None,
+        typer.Option(
+            "--classify-end",
+            help=(
+                "End of the baseline measurement window (YYYY-MM-DD). "
+                "PRs merged after this date are evaluated for outliers."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Detect PR review outliers using z-score analysis.
 
@@ -116,16 +136,32 @@ def detect_outliers(
     - Raw metrics: additions, deletions, changed_files, comments, review_comments
     - Engineered features: review_duration, code_churn, comment_density
 
-    Requires repository data to be fetched first using the 'classify' command.
+    Requires repository data to be fetched first using the 'fetch' command.
     """
     try:
         repo = GitHubRepo.from_string(repository)
         repo_name = f"{repo.owner}/{repo.name}"
 
+        classify_start_dt: datetime | None = None
+        classify_end_dt: datetime | None = None
+
+        if classify_start:
+            classify_start_dt = datetime.strptime(classify_start, "%Y-%m-%d").replace(
+                tzinfo=UTC
+            )
+        if classify_end:
+            classify_end_dt = datetime.strptime(classify_end, "%Y-%m-%d").replace(
+                hour=23, minute=59, second=59, tzinfo=UTC
+            )
+
         if verbose:
             typer.echo(f"Analyzing outliers for {repo_name}...")
             typer.echo(f"Z-score threshold: {threshold}")
             typer.echo(f"Minimum sample size: {min_samples}")
+            if classify_start_dt or classify_end_dt:
+                start_label = classify_start or "unbounded"
+                end_label = classify_end or "unbounded"
+                typer.echo(f"Classification window: {start_label} to {end_label}")
 
         from sqlmodel import select
 
@@ -155,7 +191,7 @@ def detect_outliers(
 
             if len(prs) == 0:
                 typer.echo(
-                    f"No PRs found for {repo_name}. Run 'classify' command first.",
+                    f"No PRs found for {repo_name}. Run 'fetch' command first.",
                     err=True,
                 )
                 raise typer.Exit(code=1)
@@ -173,12 +209,21 @@ def detect_outliers(
                 typer.echo("Detecting outliers...")
 
             results = detect_outliers_for_repository(
-                session, repo_name, min_samples, threshold
+                session,
+                repo_name,
+                min_samples,
+                threshold,
+                classify_start=classify_start_dt,
+                classify_end=classify_end_dt,
             )
 
-            # Get sample size for metadata
+            # Get sample size for metadata (baseline PRs within classification window)
             _, sample_size = calculate_repository_statistics(
-                session, repo_name, min_samples
+                session,
+                repo_name,
+                min_samples,
+                stats_start=classify_start_dt,
+                stats_end=classify_end_dt,
             )
 
             # Step 3: Save results

--- a/tests/test_outlier_detection_integration.py
+++ b/tests/test_outlier_detection_integration.py
@@ -173,6 +173,205 @@ def test_insufficient_data_error_raised(test_session: Session) -> None:
         detect_outliers_for_repository(test_session, repo_name, min_sample_size=30)
 
 
+def test_outlier_detection_with_classify_date_range(test_session: Session) -> None:
+    """Test that classify window is used as baseline and PRs after it are evaluated."""
+    repo_name = "test/classify-range-repo"
+
+    # Create 50 baseline PRs in Jan 2024 — these form the measurement window
+    for i in range(50):
+        pr = PullRequest(
+            repository_name=repo_name,
+            number=i,
+            title=f"Baseline PR {i}",
+            author="user",
+            created_at=datetime(2024, 1, i % 28 + 1, 10, 0, tzinfo=UTC),
+            merged_at=datetime(2024, 1, i % 28 + 1, 12, 0, tzinfo=UTC),
+            additions=90 + (i % 20),  # Varies 90-109, mean ~99, std_dev ~5.8
+            deletions=45 + (i % 10),
+            changed_files=4 + (i % 3),
+            comments=1 + (i % 3),
+            review_comments=2 + (i % 3),
+            state="closed",
+            url=f"http://test.com/baseline/{i}",
+        )
+        test_session.add(pr)
+
+    # Create 4 normal PRs in Feb 2024 — these are after classify_end, so evaluated
+    for i in range(4):
+        pr = PullRequest(
+            repository_name=repo_name,
+            number=100 + i,
+            title=f"Feb PR {i}",
+            author="user",
+            created_at=datetime(2024, 2, i + 1, 10, 0, tzinfo=UTC),
+            merged_at=datetime(2024, 2, i + 1, 12, 0, tzinfo=UTC),
+            additions=95 + i,
+            deletions=48,
+            changed_files=5,
+            comments=2,
+            review_comments=3,
+            state="closed",
+            url=f"http://test.com/feb/{i}",
+        )
+        test_session.add(pr)
+
+    # Create 1 extreme PR in Feb 2024 — after classify_end, should be flagged
+    outlier_pr = PullRequest(
+        repository_name=repo_name,
+        number=999,
+        title="Extreme Feb PR",
+        author="user",
+        created_at=datetime(2024, 2, 10, 10, 0, tzinfo=UTC),
+        merged_at=datetime(2024, 2, 10, 12, 0, tzinfo=UTC),
+        additions=10000,
+        deletions=5000,
+        changed_files=500,
+        comments=100,
+        review_comments=50,
+        state="closed",
+        url="http://test.com/feb/extreme",
+    )
+    test_session.add(outlier_pr)
+    test_session.commit()
+
+    # Compute features for all PRs
+    from sqlmodel import select
+
+    all_prs = list(test_session.exec(select(PullRequest)).all())
+    for pr in all_prs:
+        if pr.id is not None:
+            features = create_pr_features(pr)
+            test_session.add(features)
+    test_session.commit()
+
+    # classify window = Jan 2024 (used for stats); PRs after Jan 31 are evaluated
+    classify_start = datetime(2024, 1, 1, tzinfo=UTC)
+    classify_end = datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC)
+
+    results = detect_outliers_for_repository(
+        test_session,
+        repo_name,
+        min_sample_size=30,
+        classify_start=classify_start,
+        classify_end=classify_end,
+    )
+
+    # Only Feb PRs (after classify_end) should be in results
+    assert len(results) == 5
+    assert all(r.pr_number >= 100 for r in results)
+
+    # Baseline Jan PRs should not be present
+    assert not any(r.pr_number < 100 for r in results)
+
+    # Extreme Feb PR should be flagged as outlier against the Jan baseline
+    extreme = next((r for r in results if r.pr_number == 999), None)
+    assert extreme is not None
+    assert extreme.is_outlier is True
+    assert "additions" in extreme.outlier_features
+
+
+def test_classify_window_is_baseline_for_stats(test_session: Session) -> None:
+    """Test that the classification window defines the baseline used for statistics.
+
+    50 PRs in Jan 2023 form the classify window (baseline: mean≈98.5, std_dev≈5.74).
+    30 PRs in Jan 2024 (additions=115) come after classify_end and are evaluated.
+
+    With the window: z ≈ (115-98.5)/5.74 ≈ 2.87 → outlier.
+    Without the window (all 80 PRs for stats): mean≈104.7, std_dev≈9.2,
+      z ≈ (115-104.7)/9.2 ≈ 1.12 → not an outlier.
+
+    This verifies that the classify window controls which PRs feed the baseline.
+    """
+    repo_name = "test/window-stats-repo"
+
+    # 50 PRs in Jan 2023 — the baseline measurement window
+    for i in range(50):
+        pr = PullRequest(
+            repository_name=repo_name,
+            number=i,
+            title=f"Baseline PR {i}",
+            author="user",
+            created_at=datetime(2023, 1, i % 28 + 1, i % 24, 0, tzinfo=UTC),
+            merged_at=datetime(2023, 1, i % 28 + 1, (i % 24 + 2) % 24, 0, tzinfo=UTC),
+            additions=90 + (i % 20),  # mean≈98.5, std_dev≈5.74
+            deletions=50,
+            changed_files=5,
+            comments=2,
+            review_comments=3,
+            state="closed",
+            url=f"http://test.com/base/{i}",
+        )
+        test_session.add(pr)
+
+    # 30 PRs in Jan 2024 — after classify_end, so these are evaluated for outliers
+    # additions=115 is above threshold vs Jan 2023 baseline (z≈2.87) but not vs
+    # the combined 80-PR pool (z≈1.12)
+    for i in range(30):
+        pr = PullRequest(
+            repository_name=repo_name,
+            number=100 + i,
+            title=f"Classify PR {i}",
+            author="user",
+            created_at=datetime(2024, 1, i % 28 + 1, i % 24, 0, tzinfo=UTC),
+            merged_at=datetime(2024, 1, i % 28 + 1, (i % 24 + 2) % 24, 0, tzinfo=UTC),
+            additions=115,
+            deletions=50,
+            changed_files=5,
+            comments=2,
+            review_comments=3,
+            state="closed",
+            url=f"http://test.com/classify/{i}",
+        )
+        test_session.add(pr)
+
+    test_session.commit()
+
+    from sqlmodel import select
+
+    all_prs = list(test_session.exec(select(PullRequest)).all())
+    for pr in all_prs:
+        if pr.id is not None:
+            features = create_pr_features(pr)
+            test_session.add(features)
+    test_session.commit()
+
+    # classify window = Jan 2023; PRs after Jan 31 2023 are evaluated
+    classify_start = datetime(2023, 1, 1, tzinfo=UTC)
+    classify_end = datetime(2023, 1, 31, 23, 59, 59, tzinfo=UTC)
+
+    results_with_window = detect_outliers_for_repository(
+        test_session,
+        repo_name,
+        min_sample_size=30,
+        classify_start=classify_start,
+        classify_end=classify_end,
+    )
+
+    # All 30 Jan-2024 PRs should be in results (after classify_end)
+    assert len(results_with_window) == 30
+    assert all(r.pr_number >= 100 for r in results_with_window)
+
+    # With clean Jan-2023 baseline, additions=115 is a clear outlier (z≈2.87)
+    pr_with_window = next(r for r in results_with_window if r.pr_number == 100)
+    assert pr_with_window.is_outlier is True
+
+    # Without window: all 80 PRs used for stats — the Jan-2024 PRs dilute the baseline
+    results_no_window = detect_outliers_for_repository(
+        test_session,
+        repo_name,
+        min_sample_size=30,
+    )
+    pr_no_window = next(r for r in results_no_window if r.pr_number == 100)
+
+    # z_additions should be higher with the clean baseline than the diluted one
+    z_with = abs(pr_with_window.z_scores.get("z_additions") or 0.0)
+    z_without = abs(pr_no_window.z_scores.get("z_additions") or 0.0)
+    assert z_with > z_without, (
+        f"Clean baseline (z={z_with:.2f}) should give higher z_additions "
+        f"than diluted baseline (z={z_without:.2f})"
+    )
+
+
 def test_normal_distribution_few_outliers(test_session: Session) -> None:
     """Test that normal distribution produces expected outlier rate."""
     repo_name = "test/normal-repo"


### PR DESCRIPTION
## Summary

- Adds `--classify-start` / `--classify-end` options to `detect-outliers`. PRs merged within that window form the historical baseline; only PRs merged **after** `--classify-end` are evaluated for outliers. This stops extreme recent PRs from inflating the mean/std_dev of the baseline they are measured against.
- Renames the `classify` CLI command to `fetch`, which accurately reflects that it only retrieves and stores PR data.
- Updates `README.md` with full option tables, a baseline-window explanation, and an end-to-end workflow example.

## Test plan

- [ ] `uv run pytest tests/test_outlier_detection_integration.py -v` — all 6 tests pass, including the two new ones:
  - `test_outlier_detection_with_classify_date_range` — verifies only post-window PRs are returned and the extreme one is flagged
  - `test_classify_window_is_baseline_for_stats` — verifies the window controls which PRs feed the baseline by comparing z-scores with and without the window
- [ ] `uv run pytest tests/ -q --ignore=tests/test_integration.py` — 49 passed
- [ ] Smoke test with real data: `uv run review-classify fetch owner/repo --start 2024-01-01 --end 2024-12-31` then `uv run review-classify detect-outliers owner/repo --classify-start 2024-01-01 --classify-end 2024-12-31`

🤖 Generated with [Claude Code](https://claude.com/claude-code)