### PR TITLE
feat: add __main__.py to support python -m review_classification

### DIFF
--- a/src/review_classification/__main__.py
+++ b/src/review_classification/__main__.py
@@ -1,0 +1,5 @@
+"""Allows the package to be run as python -m review_classification."""
+
+from .main import main
+
+main()


### PR DESCRIPTION
## Summary

- Adds `src/review_classification/__main__.py` so the package can be executed as a module after installation from PyPI.

After `pip install review-classification`, users can invoke the CLI either way:

```bash
# existing console script
review-classify fetch owner/repo

# new: module invocation
python -m review_classification fetch owner/repo
```

## Test plan

- [ ] `uv run python -m review_classification --help` shows the full CLI help
- [ ] `uv run python -m review_classification fetch --help` and `detect-outliers --help` work as expected
- [ ] Existing test suite passes: `uv run pytest tests/ -q --ignore=tests/test_integration.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)