### PR TITLE
feat: register review-classification as a console script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,4 +48,5 @@ build-backend = "uv_build"
 review_classification = ["uv"]
 
 [project.scripts]
+review-classification = "review_classification.main:main"
 review-classify = "review_classification.main:main"


### PR DESCRIPTION
## Summary

- Adds `review-classification` to `[project.scripts]` in `pyproject.toml` so the command is available on `PATH` after `pip install review-classification`.
- Keeps `review-classify` as a shorter alias for backwards compatibility.

Previously only `review-classify` was registered, so users who installed the package and tried to run `review-classification` would get a "command not found" error.

## Test plan

- [ ] `uv run review-classification --help` shows the CLI
- [ ] `uv run review-classify --help` still works (alias preserved)
- [ ] `uv run pytest tests/ -q --ignore=tests/test_integration.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)