### PR TITLE
feat: display repository name above outlier table

### DIFF
--- a/src/review_classification/cli/app.py
+++ b/src/review_classification/cli/app.py
@@ -194,7 +194,7 @@ def _detect_single(
                 f"({len(outliers) / len(results) * 100:.1f}%)"
             )
 
-        output = format_outlier_results(results, output_format)  # type: ignore
+        output = format_outlier_results(results, output_format, repo_name=full_name)  # type: ignore
         typer.echo(output)
         return True
 

--- a/src/review_classification/cli/output.py
+++ b/src/review_classification/cli/output.py
@@ -9,6 +9,7 @@ from ..analysis.outlier_detector import OutlierResult
 def format_outlier_results(
     results: list[OutlierResult],
     format_type: Literal["table", "json", "csv"] = "table",
+    repo_name: str | None = None,
 ) -> str:
     """Format outlier detection results.
 
@@ -26,15 +27,19 @@ def format_outlier_results(
     elif format_type == "csv":
         return _format_csv(outliers)
     else:
-        return _format_table(outliers, total_prs=len(results))
+        return _format_table(outliers, total_prs=len(results), repo_name=repo_name)
 
 
-def _format_table(outliers: list[OutlierResult], total_prs: int) -> str:
+def _format_table(
+    outliers: list[OutlierResult], total_prs: int, repo_name: str | None = None
+) -> str:
     """Format as ASCII table."""
     if not outliers:
         return f"No outliers detected out of {total_prs} PRs analyzed."
 
     lines = []
+    if repo_name:
+        lines.append(f"\nRepository: {repo_name}")
     lines.append("\nOutlier Pull Requests (ordered by most recently merged)")
     lines.append("=" * 150)
     lines.append(


### PR DESCRIPTION
Print the repository name as a header line before the outlier PR table so that multi-repo runs clearly associate each table with its source repo.