### PR TITLE
feat: add license and author metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "review-classification"
 version = "0.0.7"
 description = "CLI tool to identify pull request outliers in GitHub repositories using Z-score analysis"
 readme = "README.md"
+license = {text = "MIT"}
+authors = [{name = "ghinks", email = "ghinks@yahoo.com"}]
 requires-python = ">=3.12"
 dependencies = [
     "pygithub>=2.8.1",


### PR DESCRIPTION
## Summary
- Adds `license = {text = "MIT"}` to `[project]` in `pyproject.toml`
- Adds `authors` field with name and email

These fields are displayed on the PyPI registry page when the package is published.

## Test plan
- [ ] Verify `pyproject.toml` parses correctly: `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"`
- [ ] Publish a test release and confirm license and author appear on PyPI project page

🤖 Generated with [Claude Code](https://claude.com/claude-code)