### PR TITLE
feat: add repository URL to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,8 @@ build-backend = "uv_build"
 [tool.uv.extra-build-dependencies]
 review_classification = ["uv"]
 
+[project.urls]
+Repository = "https://github.com/ghinks/review-classification"
+
 [project.scripts]
 review-classify = "review_classification.main:main"


### PR DESCRIPTION
## Summary
- Adds `[project.urls]` section with the GitHub repository link
- The URL will be displayed as a sidebar link on the PyPI project page

## Test plan
- [ ] Verify `pyproject.toml` parses correctly: `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"`
- [ ] Publish a release and confirm the repository link appears on the PyPI page

🤖 Generated with [Claude Code](https://claude.com/claude-code)