### PR TITLE
feat: tag commit with version after PyPI publish

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -64,3 +64,8 @@ jobs:
           git add pyproject.toml uv.lock
           git commit -m "chore: bump version to ${{ steps.bump.outputs.version }} [skip ci]"
           git push
+
+      - name: Tag Version
+        run: |
+          git tag "v${{ steps.bump.outputs.version }}"
+          git push origin "v${{ steps.bump.outputs.version }}"


### PR DESCRIPTION
## Summary
- Adds a `Tag Version` step to `pypi_publish.yml` that runs after the version bump commit is pushed
- Creates and pushes a git tag (e.g. `v0.0.8`) so each published release is traceable in git history

## Test plan
- [ ] Trigger the workflow via `workflow_dispatch` against TestPyPI
- [ ] Confirm a tag matching the bumped version (e.g. `v0.0.x`) appears in the repository after the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)