### PR TITLE
docs: add PyPI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,25 @@ A CLI tool to identify pull request outliers in GitHub repositories using Z-scor
 
 ## Installation
 
-**Prerequisites**: Python 3.12+, [uv](https://github.com/astral-sh/uv)
+**Prerequisites**: Python 3.12+
+
+### From PyPI (recommended)
+
+```bash
+pip install review-classification
+```
+
+Or, if you use [uv](https://github.com/astral-sh/uv):
+
+```bash
+uv tool install review-classification
+```
+
+Once installed, the `review-classify` command is available in your terminal.
+
+### From source (development)
+
+**Prerequisites**: [uv](https://github.com/astral-sh/uv)
 
 ```bash
 git clone https://github.com/ghinks/review-classification.git
@@ -21,9 +39,13 @@ cd review-classification
 uv sync
 ```
 
+When running from source, prefix all commands with `uv run` (e.g., `uv run review-classify fetch ...`).
+
 ## Usage
 
 The tool has two commands: **fetch** and **classify**.
+
+> **Note**: Examples below use `uv run review-classify` (source installs). If you installed from PyPI, omit the `uv run` prefix and call `review-classify` directly.
 
 ### 1. Configure GitHub Token
 


### PR DESCRIPTION
## Summary

- Restructures the Installation section to lead with `pip install review-classification` and `uv tool install review-classification` as the recommended approach
- Moves the clone + `uv sync` flow into a "From source (development)" subsection
- Adds a note in the Usage section clarifying that PyPI installs call `review-classify` directly (without the `uv run` prefix)

Closes #44

## Test plan

- [ ] Verify `pip install review-classification` installs the package and `review-classify --help` works
- [ ] Verify `uv tool install review-classification` works similarly
- [ ] Review README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)