### PR TITLE
docs: explain fetch/classify separation and SQLite persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,16 @@ When running from source, prefix all commands with `uv run` (e.g., `uv run revie
 
 ## Usage
 
-The tool has two commands: **fetch** and **classify**.
+The tool has two commands: **fetch** and **classify**, designed to be run separately.
+
+**Why two steps?**
+
+`fetch` calls the GitHub API and stores the raw PR data in a local SQLite database (`review_classification.db`). `classify` reads exclusively from that database — no network calls. This means you fetch once (which can take time for large organisations or wide date ranges) and then run `classify` as many times as you like, experimenting with different thresholds, date windows, or output formats, all at local speed.
+
+```
+GitHub API  ──► fetch ──► review_classification.db ──► classify ──► results
+                (once)       (persisted locally)       (fast, repeatable)
+```
 
 > **Note**: Examples below use `uv run review-classify` (source installs). If you installed from PyPI, omit the `uv run` prefix and call `review-classify` directly.
 


### PR DESCRIPTION
## Summary

- Adds a "Why two steps?" explanation at the top of the Usage section
- Clarifies that `fetch` hits the GitHub API once and stores PR data in a local SQLite database (`review_classification.db`)
- Clarifies that `classify` reads only from the local database — no network calls — so it can be re-run quickly with different thresholds, windows, or output formats
- Includes an ASCII flow diagram to make the data flow immediately visible

Closes #45

## Test plan

- [ ] Review README renders correctly on GitHub
- [ ] Diagram and explanation are clear to a first-time user

🤖 Generated with [Claude Code](https://claude.com/claude-code)