### PR TITLE
refactor: rename _fetch_single/_detect_single to _fetch_repo/_classify_repo

### DIFF
--- a/src/review_classification/cli/app.py
+++ b/src/review_classification/cli/app.py
@@ -44,7 +44,7 @@ def main(
 # ---------------------------------------------------------------------------
 
 
-def _fetch_single(
+def _fetch_repo(
     repo_name: str,
     start_date: str | None,
     end_date: str | None,
@@ -95,7 +95,7 @@ def _fetch_single(
     typer.echo(f"Successfully saved {len(prs)} PRs for {repo.owner}/{repo.name}.")
 
 
-def _detect_single(
+def _classify_repo(
     repo_name: str,
     threshold: float,
     min_samples: int,
@@ -403,7 +403,7 @@ def fetch(
         )
 
         for target in targets:
-            _fetch_single(
+            _fetch_repo(
                 target.name,
                 target.collate_start,
                 target.collate_end,
@@ -516,7 +516,7 @@ def classify(
         )
 
         repo_results = [
-            _detect_single(
+            _classify_repo(
                 target.name,
                 target.threshold if target.threshold is not None else threshold,
                 target.min_samples if target.min_samples is not None else min_samples,


### PR DESCRIPTION
## Summary

Renames two private helper functions in `cli/app.py` so their names describe what they do rather than how many repos they process.

| Before | After | Reason |
|---|---|---|
| `_fetch_single` | `_fetch_repo` | Mirrors the `fetch` CLI command; `repo` already implies a single repository |
| `_detect_single` | `_classify_repo` | Mirrors the `classify` CLI command; better reflects the full scope of work (computes features, scores outliers, saves results, returns `RepoClassifyResult`) |

No behaviour change — pure rename. Only `cli/app.py` is touched (two definitions, two call sites).

## Test plan

- [x] `grep` confirms no old names remain in the codebase
- [x] All 62 unit tests pass (`uv run pytest -m "not integration"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)