### PR TITLE
feat: resolve org repos from DB in classify (no GitHub API call)

### DIFF
--- a/src/review_classification/cli/app.py
+++ b/src/review_classification/cli/app.py
@@ -254,9 +254,7 @@ def _resolve_targets(
     if use_db_for_orgs:
         from ..sqlite.database import get_repos_for_org as _get_org_repos
     else:
-        from ..queries.github_client import (
-            get_org_repos as _get_org_repos,  # type: ignore[assignment]
-        )
+        from ..queries.github_client import get_org_repos as _get_org_repos
 
     resolved_repos: dict[str, RepoConfig] = {}
 

--- a/src/review_classification/cli/app.py
+++ b/src/review_classification/cli/app.py
@@ -243,9 +243,20 @@ def _resolve_targets(
     default_min_samples: int | None = None,
     default_start: str | None = None,
     default_end: str | None = None,
+    use_db_for_orgs: bool = False,
 ) -> list[RepoConfig]:
-    """Resolve CLI arguments and config file into a concrete list of repositories."""
-    from ..queries.github_client import get_org_repos
+    """Resolve CLI arguments and config file into a concrete list of repositories.
+
+    When use_db_for_orgs=True, org → repo expansion is done by querying the
+    local database instead of calling the GitHub API (used by classify so that
+    the command makes no network calls).
+    """
+    if use_db_for_orgs:
+        from ..sqlite.database import get_repos_for_org as _get_org_repos
+    else:
+        from ..queries.github_client import (
+            get_org_repos as _get_org_repos,  # type: ignore[assignment]
+        )
 
     resolved_repos: dict[str, RepoConfig] = {}
 
@@ -263,7 +274,7 @@ def _resolve_targets(
             add_repo(multi.resolve(repo_cfg))
 
         for org_cfg in multi.organizations:
-            org_repos = get_org_repos(org_cfg.name)
+            org_repos = _get_org_repos(org_cfg.name)
             for r in org_repos:
                 if r not in org_cfg.exclude_repos:
                     # Create a RepoConfig inheriting from org_cfg, then global
@@ -311,7 +322,7 @@ def _resolve_targets(
 
     # Add explicit CLI orgs
     for o in orgs:
-        org_repos = get_org_repos(o)
+        org_repos = _get_org_repos(o)
         for r in org_repos:
             rc = RepoConfig(
                 name=r,
@@ -513,6 +524,7 @@ def classify(
             default_min_samples=min_samples,
             default_start=start,
             default_end=end,
+            use_db_for_orgs=True,
         )
 
         repo_results = [

--- a/src/review_classification/sqlite/database.py
+++ b/src/review_classification/sqlite/database.py
@@ -117,6 +117,19 @@ def get_pr_features(pr_id: int) -> PRFeatures | None:
         return session.exec(statement).first()
 
 
+def get_repos_for_org(org_name: str) -> list[str]:
+    """Return distinct repository names stored in the DB for the given org/owner.
+
+    Avoids any network call — resolves org repos entirely from fetched data.
+    """
+    with Session(engine) as session:
+        statement = select(PullRequest).where(
+            PullRequest.repository_name.like(f"{org_name}/%")  # type: ignore[union-attr]
+        )
+        prs = list(session.exec(statement).all())
+        return sorted({pr.repository_name for pr in prs})
+
+
 def get_outlier_scores(
     repository_name: str, outliers_only: bool = True
 ) -> list[PROutlierScore]:

--- a/src/review_classification/sqlite/database.py
+++ b/src/review_classification/sqlite/database.py
@@ -123,11 +123,12 @@ def get_repos_for_org(org_name: str) -> list[str]:
     Avoids any network call — resolves org repos entirely from fetched data.
     """
     with Session(engine) as session:
-        statement = select(PullRequest).where(
-            col(PullRequest.repository_name).like(f"{org_name}/%")
+        statement = (
+            select(col(PullRequest.repository_name))
+            .where(col(PullRequest.repository_name).like(f"{org_name}/%"))
+            .distinct()
         )
-        prs = list(session.exec(statement).all())
-        return sorted({pr.repository_name for pr in prs})
+        return sorted(session.exec(statement).all())
 
 
 def get_outlier_scores(

--- a/src/review_classification/sqlite/database.py
+++ b/src/review_classification/sqlite/database.py
@@ -1,5 +1,5 @@
 from sqlalchemy import text
-from sqlmodel import Session, SQLModel, create_engine, delete, select
+from sqlmodel import Session, SQLModel, col, create_engine, delete, select
 
 from .models import PRFeatures, PROutlierScore, PullRequest
 
@@ -124,7 +124,7 @@ def get_repos_for_org(org_name: str) -> list[str]:
     """
     with Session(engine) as session:
         statement = select(PullRequest).where(
-            PullRequest.repository_name.like(f"{org_name}/%")  # type: ignore[union-attr]
+            col(PullRequest.repository_name).like(f"{org_name}/%")
         )
         prs = list(session.exec(statement).all())
         return sorted({pr.repository_name for pr in prs})

--- a/tests/sqlite/test_database.py
+++ b/tests/sqlite/test_database.py
@@ -1,0 +1,84 @@
+"""Tests for sqlite.database helper functions."""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from review_classification.sqlite.models import PullRequest
+
+
+def _make_pr(repo_name: str, number: int) -> PullRequest:
+    return PullRequest(
+        repository_name=repo_name,
+        number=number,
+        title=f"PR {number}",
+        author="user",
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        merged_at=datetime(2024, 1, 2, tzinfo=UTC),
+        additions=10,
+        deletions=5,
+        changed_files=1,
+        comments=0,
+        review_comments=0,
+        state="closed",
+        url=f"http://test.com/{number}",
+    )
+
+
+@pytest.fixture()
+def patched_engine(monkeypatch: pytest.MonkeyPatch):
+    """Replace the module-level engine with an in-memory SQLite engine."""
+    import review_classification.sqlite.database as db_module
+
+    test_engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(test_engine)
+    monkeypatch.setattr(db_module, "engine", test_engine)
+    return test_engine
+
+
+def test_get_repos_for_org_returns_correct_repos(patched_engine) -> None:
+    """get_repos_for_org returns only repos belonging to the requested org."""
+    from review_classification.sqlite.database import get_repos_for_org
+
+    with Session(patched_engine) as session:
+        session.add(_make_pr("my-org/repo-a", 1))
+        session.add(_make_pr("my-org/repo-b", 2))
+        session.add(_make_pr("other-org/repo-c", 3))
+        session.commit()
+
+    result = get_repos_for_org("my-org")
+    assert result == ["my-org/repo-a", "my-org/repo-b"]
+
+
+def test_get_repos_for_org_no_prefix_collision(patched_engine) -> None:
+    """org name prefix must be followed by '/' — no false matches for similar names."""
+    from review_classification.sqlite.database import get_repos_for_org
+
+    with Session(patched_engine) as session:
+        session.add(_make_pr("my-org/repo-a", 1))
+        session.add(_make_pr("my-org-extra/repo-b", 2))
+        session.commit()
+
+    assert get_repos_for_org("my-org") == ["my-org/repo-a"]
+    assert get_repos_for_org("my-org-extra") == ["my-org-extra/repo-b"]
+
+
+def test_get_repos_for_org_empty_when_no_data(patched_engine) -> None:  # noqa: ARG001
+    """Returns an empty list when no PRs have been fetched for the org."""
+    from review_classification.sqlite.database import get_repos_for_org
+
+    assert get_repos_for_org("unknown-org") == []
+
+
+def test_get_repos_for_org_deduplicates(patched_engine) -> None:
+    """Multiple PRs from the same repo are collapsed to one entry."""
+    from review_classification.sqlite.database import get_repos_for_org
+
+    with Session(patched_engine) as session:
+        session.add(_make_pr("my-org/repo-a", 1))
+        session.add(_make_pr("my-org/repo-a", 2))
+        session.add(_make_pr("my-org/repo-a", 3))
+        session.commit()
+
+    assert get_repos_for_org("my-org") == ["my-org/repo-a"]

--- a/tests/sqlite/test_database.py
+++ b/tests/sqlite/test_database.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 import pytest
+from sqlalchemy.engine import Engine
 from sqlmodel import Session, SQLModel, create_engine
 
 from review_classification.sqlite.models import PullRequest
@@ -27,7 +28,7 @@ def _make_pr(repo_name: str, number: int) -> PullRequest:
 
 
 @pytest.fixture()
-def patched_engine(monkeypatch: pytest.MonkeyPatch):
+def patched_engine(monkeypatch: pytest.MonkeyPatch) -> Engine:
     """Replace the module-level engine with an in-memory SQLite engine."""
     import review_classification.sqlite.database as db_module
 
@@ -37,7 +38,7 @@ def patched_engine(monkeypatch: pytest.MonkeyPatch):
     return test_engine
 
 
-def test_get_repos_for_org_returns_correct_repos(patched_engine) -> None:
+def test_get_repos_for_org_returns_correct_repos(patched_engine: Engine) -> None:
     """get_repos_for_org returns only repos belonging to the requested org."""
     from review_classification.sqlite.database import get_repos_for_org
 
@@ -51,7 +52,7 @@ def test_get_repos_for_org_returns_correct_repos(patched_engine) -> None:
     assert result == ["my-org/repo-a", "my-org/repo-b"]
 
 
-def test_get_repos_for_org_no_prefix_collision(patched_engine) -> None:
+def test_get_repos_for_org_no_prefix_collision(patched_engine: Engine) -> None:
     """org name prefix must be followed by '/' — no false matches for similar names."""
     from review_classification.sqlite.database import get_repos_for_org
 
@@ -64,14 +65,14 @@ def test_get_repos_for_org_no_prefix_collision(patched_engine) -> None:
     assert get_repos_for_org("my-org-extra") == ["my-org-extra/repo-b"]
 
 
-def test_get_repos_for_org_empty_when_no_data(patched_engine) -> None:  # noqa: ARG001
+def test_get_repos_for_org_empty_when_no_data(patched_engine: Engine) -> None:  # noqa: ARG001
     """Returns an empty list when no PRs have been fetched for the org."""
     from review_classification.sqlite.database import get_repos_for_org
 
     assert get_repos_for_org("unknown-org") == []
 
 
-def test_get_repos_for_org_deduplicates(patched_engine) -> None:
+def test_get_repos_for_org_deduplicates(patched_engine: Engine) -> None:
     """Multiple PRs from the same repo are collapsed to one entry."""
     from review_classification.sqlite.database import get_repos_for_org
 


### PR DESCRIPTION
## Summary

Closes #53

The `classify` command previously called `get_org_repos` (GitHub API) to expand `--org` into a list of repositories. This made `classify` require network access and a valid token even when all the data was already local.

### Approach

`repository_name` is already stored in the DB as `"owner/repo"`, so the org name is the prefix before `/`. Rather than adding a new column (as the issue suggested), we can query:

```sql
SELECT DISTINCT repository_name FROM pullrequest WHERE repository_name LIKE 'orgname/%'
```

This means:
- **No schema change** — the information is already there
- **No migration needed**

### Changes

| File | Change |
|---|---|
| `sqlite/database.py` | Add `get_repos_for_org(org_name)` — queries distinct `repository_name` values for the given org prefix |
| `cli/app.py` | Add `use_db_for_orgs: bool = False` to `_resolve_targets`; `classify` passes `True`, `fetch` keeps the GitHub API path |
| `tests/sqlite/test_database.py` | 4 new unit tests covering correct filtering, no prefix collisions (e.g. `my-org` vs `my-org-extra`), empty result, and deduplication |

## Test plan

- [x] 66 unit tests pass (`uv run pytest -m "not integration"`)
- [x] `get_repos_for_org("my-org")` correctly filters `my-org/repo-a` but not `my-org-extra/repo-b`
- [ ] Integration: `review-classify classify --org my-org` with data already fetched — confirm no GitHub API call is made

🤖 Generated with [Claude Code](https://claude.com/claude-code)